### PR TITLE
Clean up scripts, move tests to seperate script

### DIFF
--- a/src/eda_charts.py
+++ b/src/eda_charts.py
@@ -1,9 +1,9 @@
 # author: Arijeet Chatterjee
 # date: 2021-11-23
+# last updated on: 2021-12-03
+# last updated by: Nico Van den Hooff
 
 """
-TODO: Additional charts?
-
 Reads the pre-processed data and creates the charts for exploratory data analysis
 
 Usage: src/eda_charts.py [--input_path=<input_path>] [--output_path=<output_path>]
@@ -46,9 +46,9 @@ def chart_target_distribution(data, target_var, output_path):
         alt.Chart(data)
         .mark_bar()
         .encode(
-            y=alt.Y(target_var, type="nominal"),
-            x=alt.X("count()", title="Count"),
-            color=alt.Color("Revenue"),
+            alt.X("count()", title="Count"),
+            alt.Y(target_var, type="nominal"),
+            alt.Color("Revenue"),
         )
         .properties(width=450, height=200)
     )
@@ -109,8 +109,8 @@ def chart_categorical_var_count(data, categorical_vars, output_path):
         alt.Chart(data)
         .mark_bar()
         .encode(
-            y=alt.Y(alt.repeat(), type="nominal"),
-            x=alt.X("count()", title="Count"),
+            alt.X("count()", title="Count"),
+            alt.Y(alt.repeat(), type="nominal"),
         )
         .properties(width=450, height=200)
         .repeat(categorical_vars, columns=1)
@@ -168,8 +168,8 @@ def chart_correlation(data, output_path):
         alt.Chart(corr_df, title="Correlation Heatmap")
         .transform_filter(alt.datum.X1 < alt.datum.X2)
         .encode(
-            x=alt.X("X1", title=None),
-            y=alt.Y("X2", title=None),
+            alt.X("X1", title=None),
+            alt.Y("X2", title=None),
         )
         .properties(width=alt.Step(50), height=alt.Step(50))
     )
@@ -201,54 +201,39 @@ def main(input_path, output_path):
         Path of the folder to save the charts
 
     """
-    # print(f'Entered main func')
     df = pd.read_csv(input_path)
-    target_var = "Revenue"
+
     # Change target_var back to categorical for EDA
+    target_var = "Revenue"
     df[target_var] = np.where(df[target_var] == 1, "True", "False")
 
     numeric_cols = df.select_dtypes("number").columns.tolist()
     category_cols = ["Month", "VisitorType", "Weekend"]
 
-    print(f"Creating chart for distribution of the target variable")
     # Create chart to visualize distribution of target variable
+    print(f"-- Creating chart for distribution of the target variable")
     chart_target_distribution(data=df, target_var=target_var, output_path=output_path)
-    print(f"Creating chart for distribution of numeric variables")
+
     # Create chart to visualize distribution of numeric variables
+    print(f"-- Creating chart for distribution of numeric variables")
     chart_numeric_var_distribution(
         data=df, numeric_vars=numeric_cols, output_path=output_path
     )
+
     # Create chart to visualize categorical variables
-    print(f"Creating chart for categorical variables")
+    print(f"-- Creating chart for categorical variables")
     chart_categorical_var_count(
         data=df, categorical_vars=category_cols, output_path=output_path
     )
+
     # Create correlation plot
-    print(f"Creating correlation chart")
+    print(f"-- Creating correlation chart")
     chart_correlation(data=df, output_path=output_path)
 
     # Create Density plot
-    print(f"Creating density chart")
+    print(f"-- Creating density chart")
     density_plot(data=df, output_path=output_path)
-
-    print(f"End of EDA")
-
-
-def test_eda_charts(input_path, output_path):
-    """Test for input data type.
-
-    Parameters
-    ----------
-    input_path : str
-        Path of the data file to carry out the EDA
-    output_path : str
-        Path of the folder to save the charts
-    """
-
-    df = pd.read_csv(input_path)
-    assert isinstance(df, pd.DataFrame), "Error in df type"
 
 
 if __name__ == "__main__":
-    test_eda_charts(opt["--input_path"], opt["--output_path"])
     main(opt["--input_path"], opt["--output_path"])

--- a/src/model_selection.py
+++ b/src/model_selection.py
@@ -1,11 +1,9 @@
 # author: Nico Van den Hooff
 # created: 2021-11-23
-# last updated on: 2021-11-23
+# last updated on: 2021-12-03
 # last updated by: Nico Van den Hooff
 
 """
-TODO: Do we want precision recall curves plots?  Right now just have CMs.
-
 Reads in the pre-processed train and test data.  Splits this data into X and y arrays.
 Cross validates a selection of machine learning models and outputs the results of 
 cross validation along with confusion matrices.
@@ -306,49 +304,5 @@ def main(train, test, output_path):
         figure.savefig(name, bbox_inches="tight")
 
 
-# TODO: move tests into a seperate file
-def tests(train, test):
-    """Tests for all functions except main function.
-
-    Parameters
-    ----------
-    train_df : pandas DataFrame
-        The train DataFrame
-    test_df : pandas DataFrame
-        The test DataFrame
-    """
-
-    # test 1: test type returned by function that reads data
-    train_df, test_df = read_cleaned_data(train, test)
-    assert isinstance(train_df, pd.DataFrame, "Error in train_df type")
-    assert isinstance(test_df, pd.DataFrame, "Error in test_df type")
-
-    # test 2: test type returned by function splits data into arrays
-    X_train, X_test, y_train, y_test = get_X_y(train_df, test_df)
-    assert (
-        pd.concat(X_train, y_train, axis=1).equals(train_df),
-        "Error in Xy train split",
-    )
-    assert (
-        pd.concat(X_test, y_test, axis=1).equals(train_df),
-        "Error in Xy test split",
-    )
-
-    # test 3: test type returned by model generation function
-    models = get_models()
-    assert (isinstance(models, dict), "Error in model dictionary")
-
-    # test 3: test type returned by cross validation function
-    results_df = cross_validate_models(models, X_train, y_train)
-    assert (isinstance(results_df, pd.DataFrame), "Error in results df type")
-
-    # test 4: test type returned by cross validation function
-    cm_figures = get_confusion_matrices(models, X_train, y_train)
-    assert (isinstance(cm_figures, dict), "Error in cm_figures dictionary")
-
-    # no tests written for HTML functions as these will be changed in the future.
-
-
 if __name__ == "__main__":
-    tests(opt["--train"], opt["--test"])
     main(opt["--train"], opt["--test"], opt["--output_path"])

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,0 +1,210 @@
+# author: See individual functions
+# created: 2021-12-03
+# last updated on: 2021-12-03
+# last updated by: Nico Van den Hooff
+
+"""
+Test functions for all scripts.
+
+Usage: src/tests/tests.py [--eda=<eda_path>] [--train=<train>] [--test=<test>]
+
+Options:
+--eda=<eda>                     File path of the eda data [default: data/processed/train-eda.csv]
+--train=<train>                 File path of the train data [default: data/processed/train.csv]
+--test=<test>                   File path of the test data [default: data/processed/test.csv]
+"""
+
+
+import pandas as pd
+from docopt import docopt
+from matplotlib import figure
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import RandomizedSearchCV
+from model_selection import read_cleaned_data, get_X_y
+from data_preprocess import train_test_split, clean_data, feat_engineer
+from model_selection import get_models, cross_validate_models, get_confusion_matrices
+from tune_model import (
+    create_model_and_params,
+    perform_random_search,
+    get_search_results,
+    get_final_predictions,
+)
+
+
+opt = docopt(__doc__)
+
+
+def eda_tests(input_path):
+    # Author: Arijeet Chatterjee
+    """Tests the type of data for EDA charts
+
+    Parameters
+    ----------
+    input_path : str
+        Path of the data file to carry out the EDA
+    """
+
+    df = pd.read_csv(input_path)
+    assert isinstance(df, pd.DataFrame), "Error in df type"
+
+
+def data_process_tests():
+    # Author: Ting Zhe Yan
+    """Test functions for data_preprocess.py"""
+    # train_test_split
+    df1 = pd.DataFrame(
+        {
+            "row": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "Month": [
+                "Jan",
+                "Feb",
+                "Dec",
+                "Dec",
+                "Mar",
+                "Jan",
+                "Jan",
+                "Jan",
+                "Jan",
+                "Jan",
+            ],
+        }
+    )
+    assert len(train_test_split(df1, 0.2)[1]) == 2, "Error in train_test_split"
+    assert train_test_split(df1, 0.2)[1].iloc[0, 0] == 3, "Error in train_test_split"
+
+    # clean_data
+    df2 = pd.DataFrame({"Month": ["June"], "Revenue": 1})
+    assert clean_data(df2).iloc[0, 0] == "Jun", "Error in clean_data"
+
+    # feat_engineer
+    df3 = pd.DataFrame(
+        [[0, 0, 0, 0, 0, 0, 0, 0, 100, 1, "Feb", 1, 1, 1, 1, "TRUE", "FALSE", "FALSE"]],
+        columns=[
+            "Administrative",
+            "Administrative_Duration",
+            "Informational",
+            "Informational_Duration",
+            "ProductRelated",
+            "ProductRelated_Duration",
+            "BounceRates",
+            "ExitRates",
+            "PageValues",
+            "SpecialDay",
+            "Month",
+            "OperatingSystems",
+            "Browser",
+            "Region",
+            "TrafficType",
+            "VisitorType",
+            "Weekend",
+            "Revenue",
+        ],
+    )
+    assert (
+        feat_engineer(df3).isnull().values.any() == False
+    ), "Error in fill na in feat_engineer"
+
+
+def model_selection_tests(train, test):
+    # Author: Nico Van den Hooff
+    """Test function for model_selection.py
+
+    Parameters
+    ----------
+    train_df : pandas DataFrame
+        The train DataFrame
+    test_df : pandas DataFrame
+        The test DataFrame
+    """
+
+    # test 1: test type returned by function that reads data
+    train_df, test_df = read_cleaned_data(train, test)
+    assert isinstance(train_df, pd.DataFrame), "Error in train_df type"
+    assert isinstance(test_df, pd.DataFrame), "Error in test_df type"
+
+    # test 2: test type returned by function splits data into arrays
+    X_train, X_test, y_train, y_test = get_X_y(train_df, test_df)
+    assert pd.concat(objs=[X_train, y_train], axis=1).equals(
+        train_df
+    ), "Error in Xy train split"
+    assert pd.concat(objs=[X_train, y_train], axis=1).equals(
+        train_df
+    ), "Error in Xy test split"
+
+    # test 3: test type returned by model generation function
+    models = get_models()
+    assert isinstance(models, dict), "Error in model dictionary"
+
+    # test 3: test type returned by cross validation function
+    results_df = cross_validate_models(models, X_train, y_train)
+    assert isinstance(results_df, pd.DataFrame), "Error in results df type"
+
+    # test 4: test type returned by cross validation function
+    cm_figures = get_confusion_matrices(models, X_train, y_train)
+    assert isinstance(cm_figures, dict), "Error in cm_figures dictionary"
+
+
+def tune_model_tests(train, test):
+    # Author: Nico Van den Hooff
+    """Test function for tune_model.py
+
+    Parameters
+    ----------
+    train_df : pandas DataFrame
+        The train DataFrame
+    test_df : pandas DataFrame
+        The test DataFrame
+    """
+    train_df, test_df = read_cleaned_data(train, test)
+    X_train, X_test, y_train, y_test = get_X_y(train_df, test_df)
+
+    # test 1: test types of models and search space
+    model, search_space = create_model_and_params()
+    assert isinstance(model, RandomForestClassifier), "Incorrect model type"
+    assert isinstance(search_space, dict), "Incorrect search space type"
+
+    # test 2: test type of randomsearchcv
+    random_search = perform_random_search(X_train, y_train, model, search_space)
+    assert isinstance(
+        random_search, RandomizedSearchCV
+    ), "Random search error in return type"
+
+    # test 3: test types of results
+    results = get_search_results(random_search)
+    assert isinstance(results, dict), "Incorrect type for results"
+
+    # test 4: test types of plots and classification report
+    cm_plot, cr_df = get_final_predictions(
+        results["best_estimator"], X_train, y_train, X_test, y_test
+    )
+    assert isinstance(cm_plot, figure.Figure), "Error in CM plot type"
+    assert isinstance(cr_df, pd.DataFrame), "Error in results df type"
+
+
+def main(eda, train, test):
+    """Calls the test functions
+
+    Parameters
+    ----------
+    eda : str
+        File path of the eda data
+    train : str
+        File path of the train data
+    test : str
+        File path of the test data
+    """
+    print("Testing EDA functions")
+    eda_tests(eda)
+
+    print("Testing Data Preprocessing functions")
+    data_process_tests()
+
+    print("Testing Model Selection functions")
+    model_selection_tests(train, test)
+
+    print("Testing Model Tuning functions")
+    tune_model_tests(train, test)
+
+
+if __name__ == "__main__":
+    main(opt["--eda"], opt["--train"], opt["--test"])

--- a/src/tune_model.py
+++ b/src/tune_model.py
@@ -58,7 +58,7 @@ def create_model_and_params():
 
 
 def perform_random_search(
-    X_train, y_train, model, search_space, n_iter=100, scoring="recall"
+    X_train, y_train, model, search_space, n_iter=1, scoring="recall"
 ):
     """Performs random search cross validation.
 
@@ -202,52 +202,5 @@ def main(train, test, output_path):
     )
 
 
-# TODO: move tests into a seperate file
-def tests(train, test):
-    """Tests for all functions except main function.
-
-    Parameters
-    ----------
-    train_df : pandas DataFrame
-        The train DataFrame
-    test_df : pandas DataFrame
-        The test DataFrame
-    """
-
-    # these are tested in model_selection.py
-    train_df, test_df = read_cleaned_data(train, test)
-    X_train, X_test, y_train, y_test = get_X_y(train_df, test_df)
-
-    # take small slices to make below tests run faster
-    X_train = X_train[:10]
-    X_test = X_test[:10]
-    y_train = y_train[:10]
-    y_test = y_test[:10]
-
-    # test 1: test types of models and search space
-    model, search_space = create_model_and_params()
-    assert (isinstance(model, RandomForestClassifier), "Incorrect model type")
-    assert (isinstance(search_space, dict), "Incorrect search space type")
-
-    # test 2: test type of randomsearchcv
-    random_search = perform_random_search(X_train, y_train, model, search_space)
-    assert (
-        isinstance(random_search, RandomizedSearchCV),
-        "Random search error in return type",
-    )
-
-    # test 3: test types of results
-    results = get_search_results(random_search)
-    assert (isinstance(results, dict), "Incorrect type for results")
-
-    # test 4: test types of plots and classification report
-    cm_plot, cr_df = get_final_predictions(
-        results["best_estimator"], X_train, y_train, X_test, y_test
-    )
-    assert isinstance(cm_plot, matplotlib.pyplot.figure, "Error in CM plot type")
-    assert isinstance(cr_df, pd.DataFrame, "Error in results df type")
-
-
 if __name__ == "__main__":
-    tests(opt["--train"], opt["--test"])
     main(opt["--train"], opt["--test"], opt["--output_path"])


### PR DESCRIPTION
Summary of changes to scripts:

`data_preprocess.py`
- Move print statements to main function
- Add function to get feature types rather than having global variable and update functions affected by this
- Minor fixes for whitespace
- Move tests to `tests.py`

`eda_charts.py`
- PEP8 formatting and white space
- Update altair syntax to be consistent
- Update print statements to be consistent with other scripts
- Move tests to `tests.py`

`model_selection`, `tune_model`
- Move tests to `tests.py`

`tests.py`
- New tests script, this solves #50 